### PR TITLE
Make Jorel tasks visible in `mix help`

### DIFF
--- a/lib/mix/tasks/jorel.deb.ex
+++ b/lib/mix/tasks/jorel.deb.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Jorel.Deb do
   use Mix.Task
 
+  @shortdoc "Create a Debian package with your release"
+
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:jorel)
     :jorel.run([{:config, 'jorel.config'}, {:output_dir, './_jorel'}], [:deb])

--- a/lib/mix/tasks/jorel.dockerize.ex
+++ b/lib/mix/tasks/jorel.dockerize.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Jorel.Dockerize do
   use Mix.Task
 
+  @shortdoc "Create a Docker image with your release"
+
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:jorel)
     :jorel.run([{:config, 'jorel.config'}, {:output_dir, './_jorel'}], [:dockerize])

--- a/lib/mix/tasks/jorel.gen_config.ex
+++ b/lib/mix/tasks/jorel.gen_config.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Jorel.GenConfig do
   use Mix.Task
 
+  @shortdoc "Create a default Jorel configuration"
+
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:jorel)
     :jorel.run([{:config, 'jorel.config'}, {:output_dir, './_jorel'}], [:gen_config])

--- a/lib/mix/tasks/jorel.release.ex
+++ b/lib/mix/tasks/jorel.release.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Jorel.Release do
   use Mix.Task
 
+  @shortdoc "Release your app"
+
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:jorel)
     :jorel.run([{:config, 'jorel.config'}, {:output_dir, './_jorel'}], [:release])

--- a/lib/mix/tasks/jorel.tar.ex
+++ b/lib/mix/tasks/jorel.tar.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Jorel.Tar do
   use Mix.Task
 
+  @shortdoc "Create a Tar archive with your release"
+
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:jorel)
     :jorel.run([{:config, 'jorel.config'}, {:output_dir, './_jorel'}], [:tar])

--- a/lib/mix/tasks/jorel.zip.ex
+++ b/lib/mix/tasks/jorel.zip.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Jorel.Zip do
   use Mix.Task
 
+  @shortdoc "Create a Zip archive with your release"
+
   def run(_) do
     {:ok, _} = Application.ensure_all_started(:jorel)
     :jorel.run([{:config, 'jorel.config'}, {:output_dir, './_jorel'}], [:zip])


### PR DESCRIPTION
`mix help` used to not show any of these tasks.

The @shortdoc annotations were copied from the descriptions in
`README.md`.
